### PR TITLE
Apply rawurlencode to the given original image URL

### DIFF
--- a/lib/Thumbor/Url.php
+++ b/lib/Thumbor/Url.php
@@ -39,9 +39,9 @@ class Url
     {
         if (count($commands) > 0) {
             $commandPath = implode('/', $commands);
-            $imgPath = sprintf('%s/%s', $commandPath, $original);
+            $imgPath = sprintf('%s/%s', $commandPath, rawurlencode($original));
         } else {
-            $imgPath = $original;
+            $imgPath = rawurlencode($original);
         }
 
         $signature = $secret ? self::sign($imgPath, $secret) : 'unsafe';

--- a/tests/Thumbor/Url/BuilderTest.php
+++ b/tests/Thumbor/Url/BuilderTest.php
@@ -36,7 +36,7 @@ class BuilderTest extends TestCase
             ->smartCrop(true)
             ->addFilter('brightness', 42);
 
-        $expected = 'http://thumbor.example.com/dgzk7MVde2RUq5Hbq40FvfRdno0=/fit-in/320x240/smart/filters:brightness(42)/http://example.com/llamas.jpg';
+        $expected = 'http://thumbor.example.com/y8O2zwNvj1D6rv1qpaHTUiZjgG0=/fit-in/320x240/smart/filters:brightness(42)/http%3A%2F%2Fexample.com%2Fllamas.jpg';
 
         $this->assertEquals($expected, $url);
     }

--- a/tests/Thumbor/UrlTest.php
+++ b/tests/Thumbor/UrlTest.php
@@ -23,12 +23,12 @@ class UrlTest extends TestCase
             'http://thumbor-server:8888',
             'MY_SECURE_KEY',
             'my/big/image.jpg',
-            array('fit-in', '560x420', 'filters:fill(green)')
+            ['fit-in', '560x420', 'filters:fill(green)']
         );
 
         $this->assertEquals(
-            'http://thumbor-server:8888/bDv76lTvUdX6vORS96scx7P185c=/fit-in/560x420/filters:fill(green)/my/big/image.jpg',
-            "$url"
+            'http://thumbor-server:8888/-qITCsYPvj2Lt0ivIX1eXHhGFOM=/fit-in/560x420/filters:fill(green)/my%2Fbig%2Fimage.jpg',
+            $url
         );
     }
 
@@ -38,12 +38,27 @@ class UrlTest extends TestCase
             'http://thumbor-server:8888',
             'MY_SECURE_KEY',
             'my/big/image.jpg',
-            array()
+            []
         );
 
         $this->assertEquals(
-            'http://thumbor-server:8888/V2bYe7DAKqngbtv2GFxCcllDYWw=/my/big/image.jpg',
+            'http://thumbor-server:8888/vdLL3uSYX2E-btLe6X6JVzDccD0=/my%2Fbig%2Fimage.jpg',
             "$url"
+        );
+    }
+
+    public function testOriginalUrlIsEncoded()
+    {
+        $url = new Url(
+            'http://thumbor-server:8888',
+            'MY_SECURE_KEY',
+            'http://original.host:1234/foo?bar=baz&quu=qux',
+            []
+        );
+
+        $this->assertEquals(
+            'http://thumbor-server:8888/Y0lt8M2fp89Gxkg8UyQSOlFOpns=/http%3A%2F%2Foriginal.host%3A1234%2Ffoo%3Fbar%3Dbaz%26quu%3Dqux',
+            (string) $url
         );
     }
 }


### PR DESCRIPTION
It seems that in newer versions, Thumbor has become pickier about having the original image URL properly URL-encoded. 

As the original image URL is passed as part of an URL itself, it makes sense to completely encode it. 

Also see https://github.com/thumbor/thumbor/issues/872.
